### PR TITLE
Change default for tempest settings

### DIFF
--- a/etc/openstack_deploy/templates/user_variables.yml.j2
+++ b/etc/openstack_deploy/templates/user_variables.yml.j2
@@ -28,5 +28,5 @@ haproxy_keepalived_internal_interface: {{ hapk_int_itf | default('br-mgmt') }}
 ## Tempest settings
 tempest_public_subnet_cidr: {{ tempest_subnet | default('172.29.248.0/22') }}
 tempest_public_subnet_allocation_pools: "{{ tempest_pool | default('172.29.249.110-172.29.249.200') }}"
-tempest_install: {{ run_tempest_tests | default('no') }}
-tempest_run: {{ run_tempest_tests | default('no') }}
+tempest_install: {{ run_tempest_tests | default('yes') }}
+tempest_run: {{ run_tempest_tests | default('yes') }}


### PR DESCRIPTION
Tempest will be installed and tests will be carried out automatically
by default so that the deployment can reach some kind of validation criteria.